### PR TITLE
Wzip

### DIFF
--- a/initial-utilities/wzip/design.md
+++ b/initial-utilities/wzip/design.md
@@ -1,0 +1,19 @@
+What is the input?
+- one or more files.
+
+What is the output?
+- print the compressed string to standard output
+
+How separate things?
+- read a file as the text
+- compress the text
+  - *RLE
+- print it
+
+Trouble Shooting
+- How to read the text from the compressed file? Since it is stored as a binary file ... Can I handle it just as if it is normal ASCII?
+  - I don't think it's going to be a problem. Since I can parse ...
+- the thing is that "How to unzip '10a4b'"
+  - To do so, have to figure '10' as an integer 10.
+- How to determine the size of compreesed buffer?
+  - the worst case : the size of the compressed buffer could be double by of the original source. (e.g. 'abc' -> '1a1b1c')

--- a/initial-utilities/wzip/test.txt
+++ b/initial-utilities/wzip/test.txt
@@ -1,0 +1,1 @@
+aaaaaaaaaabbbb

--- a/initial-utilities/wzip/wzip.c
+++ b/initial-utilities/wzip/wzip.c
@@ -48,35 +48,24 @@ int write_int_to_buffer(int n, char* buffer, int index) {
 }
 
 // i use char** to pass the address that this function generates.
-void compress(char* source, char** compressed) {
+void compress(char* source) {
     // source : a plain ASCII string
     int n = strlen(source);
-    *compressed = (char*)malloc(sizeof(char) * (n*2 + 1));
-    memset(*compressed, 0,sizeof(char) * (2*n + 1));
-
-    int c_index = 0, cnt = 1;
+    int cnt = 1;
     char prev = source[0];
     for (int i = 1; i < n; i++) {
         char cur = source[i];
         if (prev == cur) {
             cnt++;
         } else {
-            // write cnt and prev
-            int add = write_int_to_buffer(cnt, *compressed, c_index);
-            c_index += add;
-            (*compressed)[c_index++] = prev;
+            fwrite(&cnt, sizeof cnt, 1, stdout);
+            fwrite(&prev, sizeof prev, 1, stdout);
             prev = cur;
             cnt = 1;
         }
     }
-    // write cnt and prev
-    int add = write_int_to_buffer(cnt, *compressed, c_index);
-    c_index += add;
-
-    // this doesn't work
-    // *compressed[c_index++] = prev;
-    // it does work! wtf!
-    (*compressed)[c_index++] = prev;
+    fwrite(&cnt, sizeof cnt, 1, stdout);
+    fwrite(&prev, sizeof prev, 1, stdout);
 }
 
 void print(char* text) {
@@ -85,10 +74,9 @@ void print(char* text) {
 }
 
 void compress_file(const char* fn) {
-    char *source, *compressed;
+    char *source;
     read_text_from_file(fn, &source);
-    compress(source, &compressed);
-    print(compressed);
+    compress(source);
 }
 
 int main(int argc, char const *argv[]) {

--- a/initial-utilities/wzip/wzip.c
+++ b/initial-utilities/wzip/wzip.c
@@ -79,6 +79,14 @@ void print(char* text) {
     fwrite(text, sizeof(char), strlen(text), stdout);
 }
 
+void compress_file(char* fn) {
+    char *source, *compressed;
+    read_text_from_file(fn, &source);
+    compress(source, &compressed);
+    print(compressed);
+}
+
 int main(int argc, char const *argv[]) {
+    compress_file("test.txt");
     return 0;
 }

--- a/initial-utilities/wzip/wzip.c
+++ b/initial-utilities/wzip/wzip.c
@@ -46,7 +46,7 @@ void compress(char* source, char** compressed) {
             // write cnt and prev
             int add = write_int_to_buffer(cnt, *compressed, c_index);
             c_index += add;
-            *compressed[c_index++] = prev;
+            (*compressed)[c_index++] = prev;
             prev = cur;
             cnt = 1;
         }
@@ -54,7 +54,11 @@ void compress(char* source, char** compressed) {
     // write cnt and prev
     int add = write_int_to_buffer(cnt, *compressed, c_index);
     c_index += add;
-    *compressed[c_index++] = prev;
+
+    // this doesn't work
+    // *compressed[c_index++] = prev;
+    // it does work! wtf!
+    (*compressed)[c_index++] = prev;
 }
 
 void print(char* text) {
@@ -75,8 +79,9 @@ int main(int argc, char const *argv[]) {
 
     // what i want here, pass the memory address which allocates in compress function.
     compress(source, &compressed);
-
     assert(strcmp(compressed, "10a4b") == 0);
+    compress("abc", &compressed);
+    assert(strcmp(compressed, "1a1b1c") == 0);
 
     free(compressed);
     return 0;

--- a/initial-utilities/wzip/wzip.c
+++ b/initial-utilities/wzip/wzip.c
@@ -1,51 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <assert.h>
-
-void read_text_from_file(const char* fn, char** text) {
-    FILE *fp = fopen(fn, "r");
-
-    if (fp == NULL) {
-        fprintf(stderr, "%s does not exist.", fn);
-        exit(1);
-    }
-
-    if (fseek(fp, 0, SEEK_END) != 0) {
-        fprintf(stderr, "fseek failed (END)");
-        exit(1);
-    }
-    long fsize = ftell(fp);
-    if (fseek(fp, 0, SEEK_SET) != 0) {
-        fprintf(stderr, "fseek failed (SET)");
-        exit(1);
-    }
-
-    *text = (char*)malloc(fsize);
-    fread(*text, 1, fsize, fp);
-
-    fclose(fp);
-}
-
-// return the length of addition to the buffer.
-int write_int_to_buffer(int n, char* buffer, int index) {
-    assert(n > 0);
-
-    // 123 -> num[0] = 3, num[1] = 2, num[2] = 1
-    // 10 -> num[0] = 0, num[1] = 1
-    uint8_t num[40] = {0};
-    int n_index = 0;
-    while (n > 0) {
-        num[n_index++] = n % 10;
-        n /= 10;
-    }
-
-    for (int i = n_index - 1; i >= 0; i--) {
-        buffer[index++] = num[i] + '0';
-    }
-
-    return n_index;
-}
 
 // i use char** to pass the address that this function generates.
 void compress(char* source) {
@@ -66,17 +21,6 @@ void compress(char* source) {
     }
     fwrite(&cnt, sizeof cnt, 1, stdout);
     fwrite(&prev, sizeof prev, 1, stdout);
-}
-
-void print(char* text) {
-    // To write out an integer in binary format.
-    fwrite(text, sizeof(char), strlen(text), stdout);
-}
-
-void compress_file(const char* fn) {
-    char *source;
-    read_text_from_file(fn, &source);
-    compress(source);
 }
 
 void aggregate_files_content(int num_files, const char* fn[], char **text) {

--- a/initial-utilities/wzip/wzip.c
+++ b/initial-utilities/wzip/wzip.c
@@ -3,8 +3,21 @@
 #include <string.h>
 #include <assert.h>
 
-void read_text_from_file(char* fn, char* text) {
+void read_text_from_file(char* fn, char** text) {
     FILE *fp = fopen(fn, "r");
+
+    if (fseek(fp, 0, SEEK_END) != 0) {
+        fprintf(stderr, "fseek failed (END)");
+        exit(1);
+    }
+    long fsize = ftell(fp);
+    if (fseek(fp, 0, SEEK_SET) != 0) {
+        fprintf(stderr, "fseek failed (SET)");
+        exit(1);
+    }
+
+    *text = (char*)malloc(fsize);
+    fread(*text, 1, fsize, fp);
 
     fclose(fp);
 }

--- a/initial-utilities/wzip/wzip.c
+++ b/initial-utilities/wzip/wzip.c
@@ -6,6 +6,11 @@
 void read_text_from_file(char* fn, char** text) {
     FILE *fp = fopen(fn, "r");
 
+    if (fp == NULL) {
+        fprintf(stderr, "%s does not exist.", fn);
+        exit(1);
+    }
+
     if (fseek(fp, 0, SEEK_END) != 0) {
         fprintf(stderr, "fseek failed (END)");
         exit(1);

--- a/initial-utilities/wzip/wzip.c
+++ b/initial-utilities/wzip/wzip.c
@@ -80,22 +80,5 @@ void print(char* text) {
 }
 
 int main(int argc, char const *argv[]) {
-    /* code */
-
-    char* source = "aaaaaaaaaabbbb";
-    char* compressed = NULL;
-
-    if (strlen(source) == 0) {
-        // there is nothing to compress
-        return 0;
-    }
-
-    // what i want here, pass the memory address which allocates in compress function.
-    compress(source, &compressed);
-    assert(strcmp(compressed, "10a4b") == 0);
-    compress("abc", &compressed);
-    assert(strcmp(compressed, "1a1b1c") == 0);
-
-    free(compressed);
     return 0;
 }

--- a/initial-utilities/wzip/wzip.c
+++ b/initial-utilities/wzip/wzip.c
@@ -9,12 +9,52 @@ void read_text_from_file(char* fn, char* text) {
     fclose(fp);
 }
 
+// return the length of addition to the buffer.
+int write_int_to_buffer(int n, char* buffer, int index) {
+    assert(n > 0);
+
+    // 123 -> num[0] = 3, num[1] = 2, num[2] = 1
+    // 10 -> num[0] = 0, num[1] = 1
+    uint8_t num[40] = {0};
+    int n_index = 0;
+    while (n > 0) {
+        num[n_index++] = n % 10;
+        n /= 10;
+    }
+
+    for (int i = n_index - 1; i >= 0; i--) {
+        buffer[index++] = num[i] + '0';
+    }
+
+    return n_index;
+}
+
 // i use char** to pass the address that this function generates.
 void compress(char* source, char** compressed) {
     // source : a plain ASCII string
     int n = strlen(source);
-    *compressed = (char*)malloc(sizeof(char)*n*2);
-    memset(*compressed, 0,sizeof(char)*2*n);
+    *compressed = (char*)malloc(sizeof(char) * (n*2 + 1));
+    memset(*compressed, 0,sizeof(char) * (2*n + 1));
+
+    int c_index = 0, cnt = 1;
+    char prev = source[0];
+    for (int i = 1; i < n; i++) {
+        char cur = source[i];
+        if (prev == cur) {
+            cnt++;
+        } else {
+            // write cnt and prev
+            int add = write_int_to_buffer(cnt, *compressed, c_index);
+            c_index += add;
+            *compressed[c_index++] = prev;
+            prev = cur;
+            cnt = 1;
+        }
+    }
+    // write cnt and prev
+    int add = write_int_to_buffer(cnt, *compressed, c_index);
+    c_index += add;
+    *compressed[c_index++] = prev;
 }
 
 void print(char* text) {
@@ -27,6 +67,11 @@ int main(int argc, char const *argv[]) {
 
     char* source = "aaaaaaaaaabbbb";
     char* compressed = NULL;
+
+    if (strlen(source) == 0) {
+        // there is nothing to compress
+        return 0;
+    }
 
     // what i want here, pass the memory address which allocates in compress function.
     compress(source, &compressed);

--- a/initial-utilities/wzip/wzip.c
+++ b/initial-utilities/wzip/wzip.c
@@ -1,0 +1,38 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+void read_text_from_file(char* fn, char* text) {
+    FILE *fp = fopen(fn, "r");
+
+    fclose(fp);
+}
+
+// i use char** to pass the address that this function generates.
+void compress(char* source, char** compressed) {
+    // source : a plain ASCII string
+    int n = strlen(source);
+    *compressed = (char*)malloc(sizeof(char)*n*2);
+    memset(*compressed, 0,sizeof(char)*2*n);
+}
+
+void print(char* text) {
+    // To write out an integer in binary format.
+    fwrite(text, sizeof(char), strlen(text), stdout);
+}
+
+int main(int argc, char const *argv[]) {
+    /* code */
+
+    char* source = "aaaaaaaaaabbbb";
+    char* compressed = NULL;
+
+    // what i want here, pass the memory address which allocates in compress function.
+    compress(source, &compressed);
+
+    assert(strcmp(compressed, "10a4b") == 0);
+
+    free(compressed);
+    return 0;
+}

--- a/initial-utilities/wzip/wzip.c
+++ b/initial-utilities/wzip/wzip.c
@@ -79,14 +79,50 @@ void compress_file(const char* fn) {
     compress(source);
 }
 
+void aggregate_files_content(int num_files, const char* fn[], char **text) {
+    FILE *fps[num_files];
+    long fsizes[num_files];
+    long total_size = 0;
+    for (int i = 0; i<num_files; i++) {
+        fps[i] = fopen(fn[i], "r");
+        if (fps[i] == NULL) {
+            fprintf(stderr, "%s does not exist.", fn[i]);
+            exit(1);
+        }
+
+        if (fseek(fps[i], 0, SEEK_END) != 0) {
+            fprintf(stderr, "fseek failed (END)");
+            exit(1);
+        }
+        fsizes[i] = ftell(fps[i]);
+        total_size += fsizes[i];
+        if (fseek(fps[i], 0, SEEK_SET) != 0) {
+            fprintf(stderr, "fseek failed (SET)");
+            exit(1);
+        }
+    }
+
+    *text = (char*)malloc(total_size);
+    long offset = 0;
+
+    for (int i = 0; i<num_files; i++) {
+        fread(*text + offset, 1, fsizes[i], fps[i]);
+        fclose(fps[i]);
+        offset += fsizes[i];
+    }
+}
+
 int main(int argc, char const *argv[]) {
     if (argc == 1) {
         printf("wzip: file1 [file2 ...]\n");
         exit(1);
     }
 
-    for (int i=1; i<argc; i++) {
-        compress_file(argv[i]);
-    }
+    char *source;
+    //FIXME: split the array to argv[1..] to only pass the files list.
+    // Is it a good way to do it?
+    aggregate_files_content(argc-1, argv + 1, &source);
+    compress(source);
+
     return 0;
 }

--- a/initial-utilities/wzip/wzip.c
+++ b/initial-utilities/wzip/wzip.c
@@ -3,7 +3,7 @@
 #include <string.h>
 #include <assert.h>
 
-void read_text_from_file(char* fn, char** text) {
+void read_text_from_file(const char* fn, char** text) {
     FILE *fp = fopen(fn, "r");
 
     if (fp == NULL) {
@@ -84,7 +84,7 @@ void print(char* text) {
     fwrite(text, sizeof(char), strlen(text), stdout);
 }
 
-void compress_file(char* fn) {
+void compress_file(const char* fn) {
     char *source, *compressed;
     read_text_from_file(fn, &source);
     compress(source, &compressed);
@@ -92,6 +92,13 @@ void compress_file(char* fn) {
 }
 
 int main(int argc, char const *argv[]) {
-    compress_file("test.txt");
+    if (argc == 1) {
+        printf("wzip: file1 [file2 ...]\n");
+        exit(1);
+    }
+
+    for (int i=1; i<argc; i++) {
+        compress_file(argv[i]);
+    }
     return 0;
 }


### PR DESCRIPTION
What I learned?

- be careful when you dereference a double pointer.
```c
char** compressed;
*compressed[1] = 'a'; // *(compressed[1]) 
(*compressed)[1] = 'a';
```

- pass a double pointer when want to allocate in the function body.

```c
char* source;

void alloc_source(char ** source) { // use a double pointer to pass the address of the allocated value in the function body
  *source = (char*)malloc(10);
}

```